### PR TITLE
po/Makefile.am: don't hardcode libdir

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -6,7 +6,7 @@
 #
 
 DOMAIN=InfoBarTunerState
-installdir = /usr/lib/enigma2/python/Plugins/Extensions/$(DOMAIN)
+installdir = $(libdir)/enigma2/python/Plugins/Extensions/$(DOMAIN)
 #GETTEXT=./pygettext.py
 GETTEXT=xgettext
 


### PR DESCRIPTION
Avoids packaging errors in case $(libdir) points elsewhere.